### PR TITLE
Fix du header text color de FAQ and Conditions pages 2

### DIFF
--- a/frontend/src/components/HeaderLayout.css
+++ b/frontend/src/components/HeaderLayout.css
@@ -11,7 +11,7 @@ body {
   top: 0;
   left: 0;
   width: 100%;
-  z-index: 999;
+  z-index: 9999;
   background-color: transparent;
   color: #fff;
   padding: 1rem 2rem;

--- a/frontend/src/pages/ConditionsDelivrance.css
+++ b/frontend/src/pages/ConditionsDelivrance.css
@@ -1,8 +1,10 @@
 .cgv-page {
     max-width: 900px;
     margin: 0 auto;
-    padding: 110px 16px 48px;
+    padding: 140px 16px 48px; /* laisse la place au header fixed (plus safe que 110) */
     line-height: 1.6;
+    position: relative;
+    z-index: 1;
   }
   
   .cgv-title {
@@ -37,13 +39,14 @@
     background: rgba(0, 0, 0, 0.04);
     border-left: 4px solid #444;
   }
+  
+  /* Lien "Revenir à la page de connexion" */
   .back-to-login-container {
-    margin-top: 32px;
-    text-align: center;
+    margin-top: 10px;
   }
   
   .back-to-login-container a {
-    color: #0066cc;
+    color: #2b6cb0;
     text-decoration: none;
     font-weight: 500;
   }
@@ -51,4 +54,4 @@
   .back-to-login-container a:hover {
     text-decoration: underline;
   }
-    
+  

--- a/frontend/src/pages/ConditionsDelivrance.jsx
+++ b/frontend/src/pages/ConditionsDelivrance.jsx
@@ -3,19 +3,24 @@ import { Link, useLocation } from "react-router-dom";
 import "./ConditionsDelivrance.css";
 
 export default function ConditionsDelivrance() {
-    const location = useLocation();
-    const isInDashboard = location.pathname.startsWith('/dashboard');
-    
-    return (
+  const location = useLocation();
+  const isInDashboard = location.pathname.startsWith("/dashboard");
+
+  return (
     <div className="cgv-page">
-      <h1 className="cgv-title">
-        CONDITIONS GÉNÉRALES DE VENTE (CGV)
-      </h1>
+      <h1 className="cgv-title">CONDITIONS GÉNÉRALES DE VENTE (CGV)</h1>
 
       <h2 className="cgv-subtitle">
-        Service de Délivrance des Certificats d’Origine<br />
+        Service de Délivrance des Certificats d’Origine
+        <br />
         Chambre de Commerce de Djibouti (CCD)
       </h2>
+
+      {!isInDashboard && (
+        <div className="back-to-login-container">
+          <Link to="/login">Revenir à la page de connexion</Link>
+        </div>
+      )}
 
       <p>
         Les présentes Conditions Générales de Vente (CGV) encadrent la fourniture
@@ -47,12 +52,15 @@ export default function ConditionsDelivrance() {
       <p>
         Le Certificat d’Origine (C.O.) est un document officiel attestant le pays
         d’origine des marchandises exportées, réexportées ou en transit à partir
-        de Djibouti.
+        de Djibouti. Il peut être requis par les autorités douanières, les
+        banques, les acheteurs ou les partenaires commerciaux.
       </p>
 
       <h4>1.3 Types de Certificats</h4>
       <ul>
-        <li>Certificat d’Origine non-préférentiel : délivré directement par la CCD.</li>
+        <li>
+          Certificat d’Origine non-préférentiel : délivré directement par la CCD.
+        </li>
         <li>
           Certificat d’Origine préférentiel : visé ou légalisé par la CCD dans le
           cadre d’un accord commercial.
@@ -63,7 +71,8 @@ export default function ConditionsDelivrance() {
       <p>
         Les présentes CGV s’appliquent à toute demande de délivrance ou de
         légalisation de C.O., soumise via la plateforme électronique ou
-        physiquement au guichet de la CCD.
+        physiquement au guichet de la CCD. Elles prévalent sur toute clause
+        contraire du demandeur.
       </p>
 
       <h3>3. MODALITÉS DE DEMANDE ET RESPONSABILITÉS</h3>
@@ -71,88 +80,92 @@ export default function ConditionsDelivrance() {
       <h4>3.1 Responsabilité du Demandeur</h4>
       <p>
         L’entreprise est responsable de l’exactitude, de la complétude et de la
-        véracité des informations fournies.
+        véracité des informations fournies. Toute omission ou fausse déclaration
+        relève de sa seule responsabilité.
       </p>
 
       <h4>3.2 Responsabilité de la CCD</h4>
       <p>
         La CCD vérifie la conformité réglementaire et délivre un C.O. authentique
-        et sécurisé.
+        et sécurisé. Elle n’est pas responsable des conséquences douanières ou
+        réglementaires dans le pays de destination.
       </p>
 
       <h3>4. TARIFICATION, FRAIS ET CONDITIONS DE PAIEMENT</h3>
 
       <h4>4.1 Tarifs</h4>
-      <p>Les tarifs sont publics, affichés et révisables.</p>
+      <p>Les tarifs de délivrance ou de légalisation sont publics, affichés et révisables.</p>
 
       <h4>4.2 Prise en charge</h4>
       <p>Les frais sont à la charge de l’entreprise demandeuse.</p>
 
       <h4>4.3 Paiement</h4>
-      <p>Le certificat est délivré uniquement après paiement complet.</p>
+      <p>Le certificat est délivré uniquement après paiement complet des frais.</p>
 
       <h3>5. DÉLAI DE TRAITEMENT ET DÉLIVRANCE</h3>
       <p>
-        Le délai indicatif est de 48 heures ouvrables, sous réserve d’un dossier
-        complet.
+        Le délai indicatif est de 48 heures ouvrables, sous réserve que le dossier
+        soit complet. Le C.O. est délivré en format électronique sécurisé.
       </p>
 
       <h3>6. RÉCLAMATIONS, ERREURS ET NON-CONFORMITÉS</h3>
 
       <p>
-        Aucune réémission gratuite ne peut être demandée lorsque l’erreur provient
-        du demandeur.
+        Aucune réémission gratuite d’un C.O validé ne peut être demandée lorsque
+        l’erreur provient de données fournies par le demandeur.
       </p>
 
       <p>
-        En cas d’erreur imputable à la CCD, la rectification est effectuée sans
-        frais.
+        En cas d’erreur matérielle imputable à la CCD, la CCD procède à la
+        rectification sans frais. Toute réclamation doit être faite dans un délai
+        de 8 jours ouvrables.
       </p>
 
       <h3>7. SUSPENSION DU SERVICE ET REFUS</h3>
       <p>
-        La CCD peut refuser ou suspendre la délivrance en cas de fraude, documents
-        incomplets ou non-paiement.
+        La CCD peut refuser ou suspendre la délivrance en cas de fraude, suspicion
+        de falsification, documents incomplets ou non-paiement.
       </p>
 
       <h3>8. LIMITATION DE RESPONSABILITÉ</h3>
       <p>
         La CCD ne peut être tenue responsable des conséquences financières,
-        douanières ou commerciales.
+        douanières ou commerciales résultant de l’usage du C.O. délivré.
       </p>
 
       <h3>9. FORCE MAJEURE</h3>
       <p>
-        Toute obligation est suspendue en cas de force majeure.
+        Toute obligation est suspendue en cas de force majeure (catastrophe,
+        grève, panne majeure, cyberattaque).
       </p>
 
       <h3>10. CONFIDENTIALITÉ ET DONNÉES PERSONNELLES</h3>
       <p>
-        Les données sont traitées de manière confidentielle conformément à la
-        législation en vigueur.
+        La CCD garantit la confidentialité des informations fournies et leur usage
+        strictement limité à la délivrance des C.O. Les données sont protégées
+        selon la législation en vigueur.
       </p>
 
       <h3>11. PROPRIÉTÉ INTELLECTUELLE</h3>
       <p>
-        Les contenus et systèmes restent la propriété exclusive de la CCD.
+        Les modèles, formulaires, contenus et systèmes liés au service restent la
+        propriété exclusive de la CCD.
       </p>
 
       <h3>12. DROIT APPLICABLE ET JURIDICTION</h3>
       <p>
-        Les présentes CGV sont régies par le droit djiboutien.
+        Les présentes CGV sont régies par le droit djiboutien. Tout litige relève
+        de la juridiction administrative de Djibouti après tentative de règlement
+        amiable.
       </p>
 
       <h3>13. ACCEPTATION FINALE</h3>
       <p>
-        La validation d’une demande vaut acceptation pleine et irrévocable des
-        présentes CGV.
+        La validation d’une demande via la plateforme ou au guichet vaut
+        acceptation pleine et irrévocable des présentes CGV. Le demandeur
+        reconnaît sa responsabilité quant à l’exactitude des informations
+        transmises.
       </p>
-      {!isInDashboard && (
-  <div className="back-to-login-container">
-    <Link to="/login">Revenir à la page de connexion</Link>
-  </div>
-)}
-
     </div>
   );
 }

--- a/frontend/src/pages/faq.css
+++ b/frontend/src/pages/faq.css
@@ -1,7 +1,9 @@
 .faq-page {
     max-width: 1000px;
     margin: 0 auto;
-    padding: 110px 16px 48px; /* laisse la place au header fixed */
+    padding: 140px 16px 48px; /* laisse la place au header fixed (plus safe que 110) */
+    position: relative;
+    z-index: 1;
   }
   
   .faq-hero {
@@ -77,13 +79,14 @@
   .faq-ol li {
     margin: 6px 0;
   }
+  
+  /* Bouton / lien "Revenir à la page de connexion" */
   .back-to-login-container {
-    margin-top: 32px;
-    text-align: center;
+    margin-top: 10px;
   }
   
   .back-to-login-container a {
-    color: #0066cc;
+    color: #2b6cb0;
     text-decoration: none;
     font-weight: 500;
   }
@@ -91,5 +94,4 @@
   .back-to-login-container a:hover {
     text-decoration: underline;
   }
-  
   

--- a/frontend/src/pages/faq.jsx
+++ b/frontend/src/pages/faq.jsx
@@ -38,49 +38,23 @@ export default function Faq() {
         ],
         isList: true,
       },
-      {
-        q: "7. Délais de délivrance",
-        a: "Les demandes sont généralement traitées immédiatement pour les entreprises vérifiées, ou sous 24h selon la complexité.",
-      },
-      {
-        q: "8. Frais de délivrance",
-        a: "Les frais varient selon la demande. Ils sont affichés sur la plateforme.",
-      },
-      {
-        q: "9. Que faire en cas de problèmes techniques ?",
-        a: "Vérifier la connexion, essayer un autre navigateur ou réduire la taille des documents. En cas de persistance : support@ccd.dj / +253 21351070.",
-      },
-      {
-        q: "10. À qui m’adresser pour des questions administratives ?",
-        a: "Service Délivrance C.O. – Chambre de Commerce.\nEmail : support@ccd.dj\nTéléphone : (+253) 21351070",
-      },
-      {
-        q: "11. Comment suivre ma demande ?",
-        a: "A chaque modification du statut de votre demande, vous réserverez une notification de la part de la CCD.",
-      },
-      {
-        q: "12. Validité internationale du C.O.",
-        a: "Le C.O. est valable internationalement mais certains pays exigent des formats spécifiques. Vérifiez toujours les exigences du pays importateur.",
-      },
-      {
-        q: "13. Modification d’une demande",
-        a: "Une modification est possible tant que la demande n’a pas été validée. Après validation, une nouvelle demande est requise.",
-      },
-      {
-        q: "14. Sécurisation du certificat d’origine en ligne",
-        a: "Le document inclut un QR code de vérification, une signature électronique et un numéro unique garantissant son authenticité.",
-      },
+      { q: "7. Délais de délivrance", a: "Les demandes sont généralement traitées immédiatement pour les entreprises vérifiées, ou sous 24h selon la complexité." },
+      { q: "8. Frais de délivrance", a: "Les frais varient selon la demande. Ils sont affichés sur la plateforme." },
+      { q: "9. Que faire en cas de problèmes techniques ?", a: "Vérifier la connexion, essayer un autre navigateur ou réduire la taille des documents. En cas de persistance : support@ccd.dj / +253 21351070." },
+      { q: "10. À qui m’adresser pour des questions administratives ?", a: "Service Délivrance C.O. – Chambre de Commerce.\nEmail : support@ccd.dj\nTéléphone : (+253) 21351070" },
+      { q: "11. Comment suivre ma demande ?", a: "A chaque modification du statut de votre demande, vous réserverez une notification de la part de la CCD." },
+      { q: "12. Validité internationale du C.O.", a: "Le C.O. est valable internationalement mais certains pays exigent des formats spécifiques. Vérifiez toujours les exigences du pays importateur." },
+      { q: "13. Modification d’une demande", a: "Une modification est possible tant que la demande n’a pas été validée. Après validation, une nouvelle demande est requise." },
+      { q: "14. Sécurisation du certificat d’origine en ligne", a: "Le document inclut un QR code de vérification, une signature électronique et un numéro unique garantissant son authenticité." },
     ],
     []
   );
-  const location = useLocation();
-  const isInDashboard = location.pathname.startsWith('/dashboard');
-  
-  const [openIndex, setOpenIndex] = useState(0);
 
-  const toggle = (idx) => {
-    setOpenIndex((prev) => (prev === idx ? -1 : idx));
-  };
+  const location = useLocation();
+  const isInDashboard = location.pathname.startsWith("/dashboard");
+
+  const [openIndex, setOpenIndex] = useState(0);
+  const toggle = (idx) => setOpenIndex((prev) => (prev === idx ? -1 : idx));
 
   return (
     <div className="faq-page">
@@ -91,6 +65,12 @@ export default function Faq() {
         <p className="faq-subtitle">
           Retrouvez ici les réponses aux questions les plus fréquentes.
         </p>
+
+        {!isInDashboard && (
+          <div className="back-to-login-container">
+            <Link to="/login">Revenir à la page de connexion</Link>
+          </div>
+        )}
       </div>
 
       <div className="faq-list">
@@ -129,12 +109,6 @@ export default function Faq() {
           );
         })}
       </div>
-      {!isInDashboard && (
-  <div className="back-to-login-container">
-    <Link to="/login">Revenir à la page de connexion</Link>
-  </div>
-)}
-
     </div>
   );
 }


### PR DESCRIPTION
Fix couleur des liens du header sur FAQ/Conditions

Ajuste padding top pour éviter chevauchement avec header fixed

Ajoute lien “Revenir à la page de connexion” propre